### PR TITLE
Allow using versions >=0.2 of leodido/conversio

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": ">=5.4",
-    "leodido/conversio": "~0.2.0"
+    "leodido/conversio": "~0.2"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.2",


### PR DESCRIPTION
With the current constraint Composer won't use leodido/conversio version 0.3 and thus is not compatible with PHP 8 / laminas/filter. With the constraint `^0.2` Composer will select version 0.3 for modern systems (PHP 8, laminas/filter) and 0.2 for older systems or for systems which rely on zendframework/filter.